### PR TITLE
Removed delay tracing from OrchestrationTestHost

### DIFF
--- a/Framework/Test/OrchestrationTestHost.cs
+++ b/Framework/Test/OrchestrationTestHost.cs
@@ -157,7 +157,6 @@ namespace DurableTask.Test
                    || clock.HasPendingTimers)
             {
                 nextDelay = clock.FirePendingTimers();
-                Trace.WriteLine("Delay: " + nextDelay);
                 if (nextDelay.Equals(TimeSpan.Zero))
                 {
                     await Task.Delay(10);


### PR DESCRIPTION
Removed the line in OrchestrationTestHost which traces delay.  This normally causes very frequent tracing that bloats test logs.